### PR TITLE
Trigger Subscribe on Log Grouop creation

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -46,6 +46,17 @@ functions:
     description: Subscribe Processor to Lambda CloudWatch Streams
     events:
       - schedule: rate(1 hour)
+      - cloudwatchEvent:
+          event:
+            source:
+              - aws.logs
+            detail-type:
+              - AWS API Call via CloudTrail
+            detail:
+              eventSource:
+                - logs.amazonaws.com
+              eventName:
+                - CreateLogGroup
 
   set-retention:
     handler: lib/handler.setRetention


### PR DESCRIPTION
This should work, but unfortunately it doesn't. Review & fix required

Reference:
http://theburningmonk.com/2017/08/centralised-logging-for-aws-lambda/